### PR TITLE
read frontmatter for image thumbsnail

### DIFF
--- a/layout/_partial/article-excerpt.ejs
+++ b/layout/_partial/article-excerpt.ejs
@@ -13,8 +13,7 @@
     <div class="card-image">
         <figure class="image is-2by1">
           
-        <% if (item.content.match(/!\[.*?\]\((.*?)\)/)){ %>
-          <img src="<%- strip_html(item.content.match(/!\[.*?\]\((.*?)\)/)[1]) %>" alt="Image">
+        <% if (item.thumbs){ %>
         <%  }else{ %>
           <img src="<%= theme.thumbimg %><%- Math.ceil(Math.random() * 10) %>" alt="Image">
         <% } %>


### PR DESCRIPTION
Most of the time using the regex to find the 1st picture of the article is not working.
It's more reliable to read an image path from the frontmatter like `thumbs`.